### PR TITLE
Support filters that replace the image URL.

### DIFF
--- a/assets/block-editor.js
+++ b/assets/block-editor.js
@@ -80,7 +80,7 @@
 			setError( response.error ?? '' );
 		} ).catch( function( error ) {
 			// The request timed out or otherwise failed.
-			console.debug( '[Share on Mastodon] "Get URL" request failed.' );
+			console.debug( '[Share on Pixelfed] "Get URL" request failed.' );
 		} );
 	};
 

--- a/assets/block-editor.js
+++ b/assets/block-editor.js
@@ -67,28 +67,21 @@
 			controller.abort();
 		}, 6000 );
 
-		try {
-			apiFetch( {
-				path: url.addQueryArgs( '/share-on-pixelfed/v1/url', { post_id: postId } ),
-				signal: controller.signal, // That time-out thingy.
-			} ).then( function( response ) {
-				clearTimeout( timeoutId );
+		apiFetch( {
+			path: url.addQueryArgs( '/share-on-pixelfed/v1/url', { post_id: postId } ),
+			signal: controller.signal, // That time-out thingy.
+		} ).then( function( response ) {
+			clearTimeout( timeoutId );
 
-				if ( response.hasOwnProperty( 'url' ) && isValidUrl( response.url ) ) {
-					setMastoUrl( response.url );
-				}
+			if ( response.hasOwnProperty( 'url' ) && isValidUrl( response.url ) ) {
+				setMastoUrl( response.url );
+			}
 
-				setError( response.error ?? '' );
-			} ).catch( function( error ) {
-				// The request timed out or otherwise failed. Leave as is.
-				throw new Error( 'The "Get URL" request failed.' )
-			} );
-		} catch ( error ) {
-			return false;
-		}
-
-		// All good.
-		return true;
+			setError( response.error ?? '' );
+		} ).catch( function( error ) {
+			// The request timed out or otherwise failed.
+			console.debug( '[Share on Mastodon] "Get URL" request failed.' );
+		} );
 	};
 
 	const unlinkUrl = ( postId, setMastoUrl ) => {

--- a/includes/class-block-editor.php
+++ b/includes/class-block-editor.php
@@ -92,7 +92,7 @@ class Block_Editor {
 	public static function permission_callback( $request ) {
 		$post_id = $request->get_param( 'post_id' );
 
-		if ( empty( $post_id ) || ! is_int( $post_id ) ) {
+		if ( empty( $post_id ) || ! ctype_digit( (string) $post_id ) ) {
 			return false;
 		}
 
@@ -114,7 +114,7 @@ class Block_Editor {
 			$post_id = $request->get_param( 'post_id' );
 		}
 
-		if ( empty( $post_id ) || ! is_int( $post_id ) ) {
+		if ( empty( $post_id ) || ! ctype_digit( (string) $post_id ) ) {
 			return new \WP_Error( 'invalid_id', 'Invalid post ID.', array( 'status' => 400 ) );
 		}
 

--- a/includes/class-image-handler.php
+++ b/includes/class-image-handler.php
@@ -80,7 +80,19 @@ class Image_Handler {
 		if ( ! empty( $image[0] ) && 0 === strpos( $image[0], $uploads['baseurl'] ) ) {
 			// Found a "large" thumbnail that lives on our own site (and not,
 			// e.g., a CDN).
-			$url = $image[0];
+
+			// Images are sometimes scaled during the upload, but you can add a filter to
+			// to replace the URL with the one pointing to the original image as follows:
+
+			// add_filter ('share_on_pixelfed_image_own_url', function($url, $id) {
+			//     return wp_get_original_image_url($id);
+			// }, 10, 2);
+
+			// Keep in mind that some pixelfed instances will also scale and compress the
+			// uploaded image, so this will only make sure that the best quality is uploaded
+			// to pixelfed, but won't prevent pixelfed from scaling and compressing the image.
+
+			$url = apply_filters ( 'share_on_pixelfed_image_own_url', $image[0], $thumb_id);
 		} else {
 			// Get the original image instead.
 			$url = wp_get_attachment_url( $thumb_id ); // Original image URL.

--- a/includes/class-post-handler.php
+++ b/includes/class-post-handler.php
@@ -88,7 +88,7 @@ class Post_Handler {
 			$post_id = $request->get_param( 'post_id' );
 		}
 
-		if ( empty( $post_id ) || ! is_int( $post_id ) ) {
+		if ( empty( $post_id ) || ! ctype_digit( (string) $post_id ) ) {
 			return new \WP_Error( 'invalid_id', 'Invalid post ID.', array( 'status' => 400 ) );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -11,18 +11,18 @@ Automatically share WordPress (image) posts on Pixelfed.
 == Description ==
 Automatically share WordPress posts on [Pixelfed](https://pixelfed.org/).
 
-You choose which Post Types are shared—though sharing can still be disabled on a per-post basis. Posts without a Featured Image will not be shared. (The plugin currently doesn't look for other images inside the post, that is.)
+You choose which post types are shared, though sharing can still be disabled on a per-post basis. (Posts without either a featured image or image content will not be shared.)
 
-Supports a number of filter hooks for developers, and is fully compatible with WordPress's new block editor.
+Supports both WordPress' block editor and the classic editor, custom post types, and more.
 
-More details can be found on [this plugin's GitHub page](https://github.com/janboddez/share-on-pixelfed).
+More details can be found on [this plugin's web page](https://jan.boddez.net/wordpress/share-on-pixelfed).
 
 == Installation ==
-Alternatively, upload this plugin's ZIP file via the "Upload Plugin" button.
+Within WP Admin, visit Plugins > Add New and search for "share on pixelfed" to locate the plugin. (Alternatively, upload this plugin’s ZIP file via the “Upload Plugin” button.)
 
 After activation, head over to *Settings > Share on Pixelfed* to authorize WordPress to post to your Pixelfed account.
 
-More detailed instructions can be found on [this plugin's GitHub page](https://github.com/janboddez/share-on-pixelfed).
+More detailed instructions can be found on [this plugin's web page](https://jan.boddez.net/wordpress/share-on-pixelfed).
 
 == Changelog ==
 = 0.9.0 =


### PR DESCRIPTION
Right now, a scaled down variant in the *large* format is uploaded to pixelfed. This commit adds support for an
*share_on_pixelfed_image_own_url* filter that is able to replace the url pointing to the large variant of the image with another one, for example one that points to the original variant of the image.